### PR TITLE
Update To Enable Development Syscalls

### DIFF
--- a/com.jetbrains.CLion.yml
+++ b/com.jetbrains.CLion.yml
@@ -5,6 +5,7 @@ runtime-version: '20.08'
 sdk: org.freedesktop.Sdk
 separate-locales: false
 finish-args:
+  - --allow=devel
   - --device=all
   - --filesystem=host
   - --filesystem=xdg-run/keyring


### PR DESCRIPTION
--allow=devel will enable Development Syscalls which should be default. Without it, debugging will not work.

Issue References:
https://github.com/flathub/com.jetbrains.CLion/issues/7#issue-849149470
https://intellij-support.jetbrains.com/hc/en-us/community/posts/360009978940/comments/360002544240