### PR TITLE
Add libsecret

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.jetbrains.CLion.yml
+++ b/com.jetbrains.CLion.yml
@@ -22,6 +22,8 @@ add-extensions:
     version: '21.08'
 
 modules:
+  - shared-modules/libsecret/libsecret.json
+
   - name: clion
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
libsecret (from the shared modules) is necessary for the GitHub login to persist