### PR TITLE
Add rsync for remote development

### DIFF
--- a/com.jetbrains.CLion.yml
+++ b/com.jetbrains.CLion.yml
@@ -24,6 +24,8 @@ add-extensions:
 modules:
   - shared-modules/libsecret/libsecret.json
 
+  - modules/rsync.yml
+
   - name: clion
     buildsystem: simple
     build-commands:

--- a/modules/rsync.yml
+++ b/modules/rsync.yml
@@ -1,0 +1,19 @@
+name: rsync
+config-opts:
+  - --prefix=${FLATPAK_DEST}
+  - --with-included-popt
+  - --with-included-zlib
+  - --disable-debug
+  - --disable-md2man
+  - --disable-xxhash
+sources:
+  - type: archive
+    url: https://download.samba.org/pub/rsync/src/rsync-3.2.7.tar.gz
+    sha256: 4e7d9d3f6ed10878c58c5fb724a67dacf4b6aac7340b13e488fb2dc41346f2bb
+    x-checker-data:
+      type: anitya
+      project-id: 4217
+      stable-only: true
+      url-template: https://download.samba.org/pub/rsync/src/rsync-$version.tar.gz
+cleanup:
+  - /share/man


### PR DESCRIPTION
Similar to https://github.com/flathub/com.jetbrains.GoLand/pull/42.

`rsync` is needed to perform header synchronization in full remote mode (at least for mappings where it cannot be explicitly disabled). With this addition everything seems to work as intended, `Tools -> Resync with Remote Hosts` needs to be invoked once to trigger synchronization.