### PR TITLE
Update git-lfs, rsync, clion and meta info

### DIFF
--- a/com.jetbrains.CLion.appdata.xml
+++ b/com.jetbrains.CLion.appdata.xml
@@ -31,12 +31,15 @@
   <developer_name>JetBrains s.r.o.</developer_name>
   <screenshots>
     <screenshot type="default">
-      <image type="source">https://www.jetbrains.com/clion/img/screens/overview__full-ide-screen.png</image>
+      <image type="source">https://www.jetbrains.com/clion/img/clion_ide_overview.png</image>
     </screenshot>
   </screenshots>
   <update_contact>digitalstreamio@gmail.com</update_contact>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release version="2024.1.3" date="2024-06-10">
+      <description></description>
+    </release>
     <release version="2023.3.1" date="2023-12-12"/>
     <release version="2023.2.2" date="2023-09-13"/>
     <release version="2023.2.1" date="2023-08-24"/>

--- a/com.jetbrains.CLion.yml
+++ b/com.jetbrains.CLion.yml
@@ -72,8 +72,8 @@ modules:
       - type: archive
         only-arches:
           - x86_64
-        sha256: 60b7e9b9b4bca04405af58a2cd5dff3e68a5607c5bc39ee88a5256dd7a07f58c
-        url: https://github.com/git-lfs/git-lfs/releases/download/v3.4.0/git-lfs-linux-amd64-v3.4.0.tar.gz
+        sha256: 6f28eb19faa7a968882dca190d92adc82493378b933958d67ceaeb9ebe4d731e
+        url: https://github.com/git-lfs/git-lfs/releases/download/v3.5.1/git-lfs-linux-amd64-v3.5.1.tar.gz
         x-checker-data:
           project-id: 11551
           stable-only: true
@@ -82,8 +82,8 @@ modules:
       - type: archive
         only-arches:
           - aarch64
-        sha256: aee90114f8f2eb5a11c1a6e9f1703a2bfcb4dc1fc4ba12a3a574c3a86952a5d0
-        url: https://github.com/git-lfs/git-lfs/releases/download/v3.4.0/git-lfs-linux-arm64-v3.4.0.tar.gz
+        sha256: 4f8700aacaa0fd26ae5300fb0996aed14d1fd0ce1a63eb690629c132ff5163a9
+        url: https://github.com/git-lfs/git-lfs/releases/download/v3.5.1/git-lfs-linux-arm64-v3.5.1.tar.gz
         x-checker-data:
           project-id: 11551
           stable-only: true
@@ -145,8 +145,8 @@ modules:
       - --with-included-zlib
     sources:
       - type: archive
-        url: https://download.samba.org/pub/rsync/src/rsync-3.2.7.tar.gz
-        sha256: 4e7d9d3f6ed10878c58c5fb724a67dacf4b6aac7340b13e488fb2dc41346f2bb
+        url: https://download.samba.org/pub/rsync/src/rsync-3.3.0.tar.gz
+        sha256: 7399e9a6708c32d678a72a63219e96f23be0be2336e50fd1348498d07041df90
         x-checker-data:
           project-id: 4217
           stable-only: true
@@ -184,9 +184,9 @@ modules:
         path: idea.properties
       - type: extra-data
         filename: clion.tar.gz
-        sha256: 3cde2fc25c759d4e114c5a768547e1d3083710e0fbe2591084a4ad4934490fc9
-        size: 905503377
-        url: https://download.jetbrains.com/cpp/CLion-2023.3.1.tar.gz
+        sha256: 96f90b3898ce1393381f4ba4a46356b07993bb44e09680df383898bca3f508a3
+        size: 1229567638
+        url: https://download.jetbrains.com/cpp/CLion-2024.1.3.tar.gz
         only-arches:
           - x86_64
         x-checker-data:
@@ -195,9 +195,9 @@ modules:
           is-main-source: true
       - type: extra-data
         filename: clion.tar.gz
-        sha256: 8aa207ee92f518fafc93b5a3bece67f15ce65ee18b8e6c28a393e8dbc0a5ef4f
-        size: 907750137
-        url: https://download.jetbrains.com/cpp/CLion-2023.3.1-aarch64.tar.gz
+        sha256: 0609fefc65d5bafcb4fff54d9c4b135ec305d058dc3f350f659c6389bf944eb9
+        size: 1228258897
+        url: https://download.jetbrains.com/cpp/CLion-2024.1.3-aarch64.tar.gz
         only-arches:
           - aarch64
         x-checker-data:


### PR DESCRIPTION
git-lfs: Update git-lfs-linux-amd64-v3.4.0.tar.gz to 3.5.1
git-lfs: Update git-lfs-linux-arm64-v3.4.0.tar.gz to 3.5.1
rsync: Update rsync-3.2.7.tar.gz to 3.3.0
clion: Update clion.tar.gz to 2024.1.3
Meta: Update screenshot link