### PR TITLE
fix: remove discordapp filesystem create

### DIFF
--- a/com.jetbrains.CLion.yml
+++ b/com.jetbrains.CLion.yml
@@ -12,7 +12,6 @@ finish-args:
   - --device=all
   - --env=CLION_PROPERTIES=/app/bin/idea.properties
   - --filesystem=host
-  - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --filesystem=xdg-run/docker
   - --filesystem=xdg-run/gnupg
   - --filesystem=xdg-run/keyring


### PR DESCRIPTION
Unless I'm missing something, this line isn't needed and is confusing, maybe result of some copypaste?

originally added in: https://github.com/flathub/com.jetbrains.CLion/pull/54/files#diff-dd13aa47fcc77408bb254d0a683fe3350b805fb98ba55538c02dfa0706df4ca9R15

Seems not needed to keep?

Thanks!