### PR TITLE
feat: Add access to the file manager

### DIFF
--- a/com.jetbrains.CLion.yml
+++ b/com.jetbrains.CLion.yml
@@ -24,6 +24,7 @@ finish-args:
   - --talk-name=org.freedesktop.Flatpak
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.freedesktop.FileManager1
   - --talk-name=org.gnome.keyring.SystemPrompter
 
 add-extensions:


### PR DESCRIPTION
I fixed the issue when using the action RevealIn in https://github.com/JetBrains/intellij-community/pull/3398. This change needs `org.freedesktop.FileManager1` to work correctly.