### PR TITLE
chore: Use Wayland by default

### DIFF
--- a/com.jetbrains.CLion.yml
+++ b/com.jetbrains.CLion.yml
@@ -19,7 +19,8 @@ finish-args:
   - --share=network
   - --socket=gpg-agent
   - --socket=ssh-auth
-  - --socket=x11
+  - --socket=fallback-x11
+  - --socket=wayland
   - --talk-name=com.canonical.AppMenu.Registrar
   - --talk-name=org.freedesktop.Flatpak
   - --talk-name=org.freedesktop.Notifications


### PR DESCRIPTION
Enable Wayland with X11 as fallback. Starting with 2026.1, IntelliJ-based IDEs will run natively on Wayland.
https://blog.jetbrains.com/platform/2026/02/wayland-by-default-in-2026-1-eap/

This change requires: #132 